### PR TITLE
Disable heightmap encoder and use raw 81-dim heightmap directly

### DIFF
--- a/legged_gym/algorithm/__init__.py
+++ b/legged_gym/algorithm/__init__.py
@@ -1,0 +1,15 @@
+from .actor_critic import ActorCritic
+from .mlp_encoder import MLP_Encoder
+from .heightmap_encoder import HeightmapEncoder
+from .ppo import PPO
+from .on_policy_runner import OnPolicyRunner
+from .rollout_storage import RolloutStorage
+
+__all__ = [
+    "ActorCritic",
+    "MLP_Encoder", 
+    "HeightmapEncoder",
+    "PPO",
+    "OnPolicyRunner",
+    "RolloutStorage",
+]

--- a/legged_gym/algorithm/heightmap_encoder.py
+++ b/legged_gym/algorithm/heightmap_encoder.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: Copyright (c) 2021 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# Copyright (c) 2021 ETH Zurich, Nikita Rudin
+
+import numpy as np
+import torch
+import torch.nn as nn
+from torch.distributions import Normal
+
+
+class HeightmapEncoder(nn.Module):
+    """
+    MLP-based encoder for GT heightmap data that compresses terrain height information
+    from sampled points around the robot into a compact representation for critic privileged information.
+    Only processes clean GT heightmap data, no noise simulation.
+    """
+    is_heightmap_encoder = True
+    is_vae = False
+
+    def __init__(
+        self,
+        num_input_dim,  # Number of height points (same as MLP_Encoder pattern)
+        num_output_dim,  # Dimension of compressed representation
+        hidden_dims=[256, 256],  # Hidden dimensions for MLP layers (same as MLP_Encoder default)
+        activation="elu",
+        orthogonal_init=False,
+        output_detach=False,
+        **kwargs,
+    ):
+        if kwargs:
+            print(
+                "HeightmapEncoder.__init__ got unexpected arguments, which will be ignored: "
+                + str([key for key in kwargs.keys()])
+            )
+        super(HeightmapEncoder, self).__init__()
+
+        self.orthogonal_init = orthogonal_init
+        self.output_detach = output_detach
+        self.num_input_dim = num_input_dim
+        self.num_output_dim = num_output_dim
+
+        activation = get_activation(activation)
+
+        if num_output_dim > 0:
+            # Encoder - EXACTLY same structure as MLP_Encoder
+            encoder_layers = []
+            encoder_layers.append(nn.Linear(num_input_dim, hidden_dims[0]))
+            if self.orthogonal_init:
+                torch.nn.init.orthogonal_(encoder_layers[-1].weight, np.sqrt(2))
+            encoder_layers.append(activation)
+            for l in range(len(hidden_dims)):
+                if l == len(hidden_dims) - 1:
+                    encoder_layers.append(nn.Linear(hidden_dims[l], num_output_dim))
+                    if self.orthogonal_init:
+                        torch.nn.init.orthogonal_(encoder_layers[-1].weight, 0.01)
+                        torch.nn.init.constant_(encoder_layers[-1].bias, 0.0)
+                else:
+                    encoder_layers.append(nn.Linear(hidden_dims[l], hidden_dims[l + 1]))
+                    if self.orthogonal_init:
+                        torch.nn.init.orthogonal_(encoder_layers[-1].weight, np.sqrt(2))
+                        torch.nn.init.constant_(encoder_layers[-1].bias, 0.0)
+                    encoder_layers.append(activation)
+            self.encoder = nn.Sequential(*encoder_layers)
+        else:
+            # Disabled encoder - create dummy network
+            self.encoder = nn.Identity()
+
+        print(f"HeightmapEncoder MLP: {self.encoder}")
+
+        # disable args validation for speedup
+        Normal.set_default_validate_args = False
+
+    def forward(self, input):
+        if self.num_output_dim == 0:
+            return torch.zeros((input.shape[0], 0), device=input.device, dtype=input.dtype)
+        # Normalize input for stability
+        input_normalized = self._normalize_input(input)
+        return self.encoder(input_normalized)
+
+    def encode(self, input):
+        if self.num_output_dim == 0:
+            self.encoder_out = torch.zeros((input.shape[0], 0), device=input.device, dtype=input.dtype)
+            return self.encoder_out
+        # Normalize input for stability
+        input_normalized = self._normalize_input(input)
+        self.encoder_out = self.encoder(input_normalized)
+        if self.output_detach:
+            return self.encoder_out.detach()
+        else:
+            return self.encoder_out
+    
+    def _normalize_input(self, input):
+        """Simple normalization for GT heightmap data"""
+        # Simple normalization for clean GT data
+        mean = input.mean()
+        std = input.std() + 1e-6
+        
+        normalized = (input - mean) / std
+        # Gentle clamping to preserve GT information
+        normalized = torch.clamp(normalized, -3.0, 3.0)
+        return normalized
+
+    def get_encoder_out(self):
+        return self.encoder_out
+
+    def inference(self, input):
+        with torch.no_grad():
+            return self.encoder(input)
+    
+
+
+def get_activation(act_name):
+    """Get activation function by name"""
+    if act_name == "elu":
+        return nn.ELU()
+    elif act_name == "selu":
+        return nn.SELU()
+    elif act_name == "relu":
+        return nn.ReLU()
+    elif act_name == "crelu":
+        return nn.ReLU()
+    elif act_name == "lrelu":
+        return nn.LeakyReLU()
+    elif act_name == "tanh":
+        return nn.Tanh()
+    elif act_name == "sigmoid":
+        return nn.Sigmoid()
+    else:
+        print("invalid activation function!")
+        return None
+
+# Backwards-compatibility alias to match config name
+# This lets eval("Heightmap_Encoder") resolve without changing configs
+Heightmap_Encoder = HeightmapEncoder

--- a/legged_gym/algorithm/on_policy_runner.py
+++ b/legged_gym/algorithm/on_policy_runner.py
@@ -41,6 +41,7 @@ import numpy as np
 from .ppo import PPO
 from .mlp_encoder import MLP_Encoder
 from .actor_critic import ActorCritic
+from .heightmap_encoder import Heightmap_Encoder
 from legged_gym.envs.vec_env import VecEnv
 
 
@@ -48,6 +49,7 @@ class OnPolicyRunner:
     def __init__(self, env: VecEnv, train_cfg, log_dir=None, device="cpu"):
         self.cfg = train_cfg["runner"]
         self.ecd_cfg = train_cfg[self.cfg["encoder_class_name"]]
+        self.hm_ecd_cfg = train_cfg[self.cfg["heightmap_encoder_class_name"]]
         self.alg_cfg = train_cfg["algorithm"]
         self.policy_cfg = train_cfg["policy"]
         self.device = device
@@ -57,15 +59,22 @@ class OnPolicyRunner:
             **self.ecd_cfg,
         ).to(self.device)
 
+        heightmap_encoder = eval(self.cfg["heightmap_encoder_class_name"])(
+            **self.hm_ecd_cfg,
+        ).to(self.device)
+
         num_critic_obs = self.env.num_critic_obs + self.env.num_commands
         if self.alg_cfg["critic_take_latent"]:
             num_critic_obs += encoder.num_output_dim
+            if heightmap_encoder.num_output_dim > 0:
+                num_critic_obs += heightmap_encoder.num_output_dim
+
+        # Calculate actor input dimensions (no heightmap for actor)
+        actor_input_dim = (self.env.num_obs + encoder.num_output_dim + self.env.num_commands)
 
         actor_critic_class = eval(self.cfg["policy_class_name"])  # ActorCritic
         actor_critic: ActorCritic = actor_critic_class(
-            self.env.num_obs
-            + encoder.num_output_dim
-            + self.env.num_commands,
+            actor_input_dim,
             num_critic_obs,
             self.env.num_actions,
             **self.policy_cfg,
@@ -75,6 +84,7 @@ class OnPolicyRunner:
         self.alg = alg_class(
             self.env.num_envs,
             encoder,
+            heightmap_encoder,
             actor_critic,
             device=self.device,
             **self.alg_cfg,
@@ -87,7 +97,7 @@ class OnPolicyRunner:
         self.alg.init_storage(
             self.env.num_envs,
             self.num_steps_per_env,
-            [self.env.num_obs],
+            [self.env.num_obs],  # Store base observations only, not actor input
             [num_critic_obs],
             [self.env.obs_history_length * self.env.num_obs],
             [self.env.num_commands],
@@ -144,6 +154,7 @@ class OnPolicyRunner:
             commands.to(self.device),
             critic_obs.to(self.device),
         )
+        # Heightmap is now included directly in critic_obs from environment
         # ???
         self.alg.actor_critic.train()  # switch to train mode (for dropout for example)
 
@@ -202,15 +213,28 @@ class OnPolicyRunner:
                 critic_obs_ = torch.cat((critic_obs, commands), dim=-1)
                 if self.alg.critic_take_latent:
                     encoder_out = self.alg.encoder.encode(obs_history)
-                    self.alg.compute_returns(
-                        torch.cat((critic_obs_, encoder_out), dim=-1)
-                    )
+                    # Add GT heightmap encoding for critic only (privileged information)
+                    if self.alg.heightmap_encoder.num_output_dim > 0:
+                        if gt_heightmap is not None:
+                            # Only use GT heightmap for critic privileged information
+                            heightmap_encoded = self.alg.heightmap_encoder.encode(gt_heightmap)
+                        else:
+                            heightmap_encoded = torch.zeros(
+                                (critic_obs_.shape[0], self.alg.heightmap_encoder.num_output_dim), 
+                                device=self.device, dtype=critic_obs_.dtype
+                            )
+                        critic_input = torch.cat((critic_obs_, encoder_out, heightmap_encoded), dim=-1)
+                    else:
+                        # No heightmap encoder - just use MLP encoder
+                        critic_input = torch.cat((critic_obs_, encoder_out), dim=-1)
+                    
+                    self.alg.compute_returns(critic_input)
                 else:
                     self.alg.compute_returns(critic_obs_)
 
             (
                 mean_value_loss,
-                mean_extra_loss,
+                mean_mlp_loss,
                 mean_surrogate_loss,
                 mean_kl,
             ) = self.alg.update()
@@ -260,7 +284,7 @@ class OnPolicyRunner:
         self.writer.add_scalar(
             "Loss/value_function", locs["mean_value_loss"], locs["it"]
         )
-        self.writer.add_scalar("Loss/encoder", locs["mean_extra_loss"], locs["it"])
+        self.writer.add_scalar("Loss/mlp_encoder", locs["mean_mlp_loss"], locs["it"])
         self.writer.add_scalar(
             "Loss/surrogate", locs["mean_surrogate_loss"], locs["it"]
         )

--- a/legged_gym/algorithm/ppo.py
+++ b/legged_gym/algorithm/ppo.py
@@ -33,6 +33,7 @@ import torch.nn as nn
 import torch.optim as optim
 
 from .mlp_encoder import MLP_Encoder
+from .heightmap_encoder import HeightmapEncoder
 from .actor_critic import ActorCritic
 from .rollout_storage import RolloutStorage
 
@@ -40,11 +41,13 @@ from .rollout_storage import RolloutStorage
 class PPO:
     actor_critic: ActorCritic
     encoder: MLP_Encoder
+    heightmap_encoder: HeightmapEncoder
 
     def __init__(
         self,
         num_group,
         encoder,
+        heightmap_encoder,
         actor_critic,
         num_learning_epochs=1,
         num_mini_batches=1,
@@ -65,6 +68,7 @@ class PPO:
         early_stop=False,
         anneal_lr=False,
         device="cpu",
+        **kwargs,
     ):
         self.device = device
         self.num_group = num_group
@@ -76,8 +80,10 @@ class PPO:
         self.anneal_lr = anneal_lr
         self.vae_beta = vae_beta
         self.critic_take_latent = critic_take_latent
+        self.critic_use_gt_heightmap = kwargs.get('critic_use_gt_heightmap', True)
 
         self.encoder = encoder
+        self.heightmap_encoder = heightmap_encoder
 
         # PPO components
         self.actor_critic = actor_critic
@@ -85,12 +91,18 @@ class PPO:
         self.storage = None  # initialized later
         self.optimizer = optim.Adam([{"params": self.actor_critic.parameters()}], lr=learning_rate)
 
+        # Setup optimizers for encoders
+        encoder_params = []
         if self.encoder.num_output_dim != 0:
-            self.extra_optimizer = optim.Adam(
-                self.encoder.parameters(), lr=est_learning_rate
-            )
+            encoder_params.extend(self.encoder.parameters())
+        if self.heightmap_encoder.num_output_dim != 0:
+            encoder_params.extend(self.heightmap_encoder.parameters())
+        
+        if encoder_params:
+            self.extra_optimizer = optim.Adam(encoder_params, lr=est_learning_rate)
         else:
             self.extra_optimizer = None
+            
         self.transition = RolloutStorage.Transition()
 
         # PPO parameters
@@ -135,13 +147,29 @@ class PPO:
         critic_obs = torch.cat((critic_obs, commands), dim=-1)
         # act
         encoder_out = self.encoder.encode(obs_history)
-        self.transition.actions = self.actor_critic.act(
-            torch.cat((encoder_out, obs, commands), dim=-1)
-        ).detach()
+        
+        
+        # Actor no longer uses heightmap - removed noisy heightmap input
+        actor_input = torch.cat((encoder_out, obs, commands), dim=-1)
+            
+        self.transition.actions = self.actor_critic.act(actor_input).detach()
 
-        # evaluate
+        # evaluate with heightmap for critic only
         if self.critic_take_latent:
-            critic_obs = torch.cat((critic_obs, encoder_out), dim=-1)
+            if self.heightmap_encoder.num_output_dim > 0:
+                # Heightmap encoder enabled - extract heightmap from critic_obs and encode
+                # critic_obs contains: base_lin_vel(3) + obs_buf(30) + heightmap(81) = 114
+                heightmap_from_obs = critic_obs[:, -81:]  # Extract last 81 dimensions (heightmap)
+                gt_heightmap_encoded = self.heightmap_encoder.encode(heightmap_from_obs)
+                critic_obs = torch.cat((critic_obs, encoder_out, gt_heightmap_encoded), dim=-1)
+            else:
+                # Heightmap encoder disabled - use raw heightmap directly
+                # critic_obs already contains: base_lin_vel(3) + obs_buf(30) + heightmap(81) = 114
+                # Just add encoder output
+                critic_obs = torch.cat((critic_obs, encoder_out), dim=-1)
+        else:
+            # If critic_take_latent is False, don't add encoder outputs
+            pass
         self.transition.values = self.actor_critic.evaluate(critic_obs).detach()
 
         # storage
@@ -203,12 +231,14 @@ class PPO:
         ) in generator:
             encoder_out_batch = self.encoder.encode(obs_history_batch)
             commands_batch = group_commands_batch
-            self.actor_critic.act(
-                torch.cat(
-                    (encoder_out_batch, obs_batch, commands_batch),
-                    dim=-1,
-                )
+            
+            # Actor no longer uses heightmap - removed from actor input
+            actor_input_batch = torch.cat(
+                (encoder_out_batch, obs_batch, commands_batch),
+                dim=-1,
             )
+            
+            self.actor_critic.act(actor_input_batch)
 
             actions_log_prob_batch = self.actor_critic.get_actions_log_prob(
                 actions_batch
@@ -287,6 +317,7 @@ class PPO:
             # Gradient step
             self.optimizer.zero_grad()
             loss.backward()
+            
             nn.utils.clip_grad_norm_(self.actor_critic.parameters(), self.max_grad_norm)
             self.optimizer.step()
 
@@ -296,7 +327,7 @@ class PPO:
             mean_kl += kl_mean.item()
 
         num_updates_extra = 0
-        mean_extra_loss = 0
+        mean_mlp_loss = 0
         if self.extra_optimizer is not None:
             generator = self.storage.encoder_mini_batch_generator(
                 self.num_mini_batches, self.num_learning_epochs
@@ -306,29 +337,46 @@ class PPO:
                 critic_obs_batch,
                 obs_history_batch,
             ) in generator:
+                # MLP Encoder loss
+                mlp_loss = torch.tensor(0.0, device=self.device)
                 if self.encoder.is_mlp_encoder:
                     self.encoder.encode(obs_history_batch)
                     encode_batch = self.encoder.get_encoder_out()
-
-                if self.encoder.is_mlp_encoder:
-                    extra_loss = (
+                    mlp_loss = (
                         (encode_batch[:, 0:3] - critic_obs_batch[:, 0:3]).pow(2).mean()
                     )
-                else:
-                    extra_loss = torch.zeros_like(value_loss)
+                
+                # Combine losses for encoder training
+                extra_loss = mlp_loss
 
                 self.extra_optimizer.zero_grad()
                 extra_loss.backward()
+                # Add gradient clipping for encoder stability
+                if hasattr(self.encoder, 'parameters'):
+                    nn.utils.clip_grad_norm_(self.encoder.parameters(), self.max_grad_norm)
+                if hasattr(self.heightmap_encoder, 'parameters'):
+                    nn.utils.clip_grad_norm_(self.heightmap_encoder.parameters(), self.max_grad_norm)
                 self.extra_optimizer.step()
 
                 num_updates_extra += 1
-                mean_extra_loss += extra_loss.item()
+                mean_mlp_loss += mlp_loss.item()
 
-        mean_value_loss /= num_updates
+        # Prevent division by zero
+        if num_updates > 0:
+            mean_value_loss /= num_updates
+            mean_surrogate_loss /= num_updates
+            mean_kl /= num_updates
+        else:
+            print("Warning: No PPO updates performed due to early stopping")
+            mean_value_loss = 0.0
+            mean_surrogate_loss = 0.0
+            mean_kl = 0.0
+            
         if num_updates_extra > 0:
-            mean_extra_loss /= num_updates
-        mean_surrogate_loss /= num_updates
-        mean_kl /= num_updates
+            mean_mlp_loss /= num_updates_extra
+        else:
+            mean_mlp_loss = 0.0
+            
         self.storage.clear()
 
-        return (mean_value_loss, mean_extra_loss, mean_surrogate_loss, mean_kl)
+        return (mean_value_loss, mean_mlp_loss, mean_surrogate_loss, mean_kl)

--- a/legged_gym/envs/base/base_task.py
+++ b/legged_gym/envs/base/base_task.py
@@ -148,11 +148,16 @@ class BaseTask:
     def reset(self):
         """Reset all robots"""
         self.reset_idx(torch.arange(self.num_envs, device=self.device))
-        obs, _, _, _, _, _, _ = self.step(
+        ret = self.step(
             torch.zeros(
                 self.num_envs, self.num_actions, device=self.device, requires_grad=False
             )
         )
+        # Support envs that return extra values (e.g., heightmaps)
+        if isinstance(ret, (list, tuple)):
+            obs = ret[0]
+        else:
+            obs = ret
         return obs
 
     def step(self, actions):

--- a/legged_gym/envs/pointfoot_flat/pointfoot_flat.py
+++ b/legged_gym/envs/pointfoot_flat/pointfoot_flat.py
@@ -12,8 +12,10 @@ from legged_gym.envs.base.base_task import BaseTask
 from legged_gym.utils.terrain import Terrain
 from legged_gym.utils.helpers import class_to_dict
 from legged_gym.utils.math import (
+    quat_apply,
     quat_apply_yaw,
     wrap_to_pi,
+    torch_rand_float,
     torch_rand_sqrt_float,
 )
 from .pointfoot_flat_config import BipedCfgPF
@@ -90,6 +92,7 @@ class BipedPF(BaseTask):
         # return clipped obs, clipped states (None), rewards, dones and infos
         clip_obs = self.cfg.normalization.clip_observations
         self.obs_buf = torch.clip(self.obs_buf, -clip_obs, clip_obs)
+        
         return (
             self.obs_buf,
             self.rew_buf,
@@ -99,6 +102,12 @@ class BipedPF(BaseTask):
             self.commands[:, :3] * self.commands_scale,
             self.critic_obs_buf # make sure critic_obs update in every for loop
         )
+    
+    def get_gt_heightmap(self):
+        """Get GT heightmap data for critic only (privileged information)"""
+        if hasattr(self, 'measured_heights') and self.measured_heights is not None:
+            return self.measured_heights.clone()
+        return None
 
     def _resample_commands(self, env_ids):
         """Randommly select commands of some environments
@@ -300,8 +309,16 @@ class BipedPF(BaseTask):
             ),
             dim=-1,
         )
+        # Add raw heightmap data (81 dimensions) directly to critic observations
+        if hasattr(self, 'measured_heights') and self.measured_heights is not None:
+            # Use actual measured heightmap data
+            heightmap_data = self.measured_heights
+        else:
+            # Fallback to zeros if no heightmap available
+            heightmap_data = torch.zeros((self.num_envs, 81), device=self.device, dtype=self.obs_buf.dtype)
+        
         critic_obs_buf = torch.cat((
-            self.base_lin_vel * self.obs_scales.lin_vel, self.obs_buf), dim=-1)
+            self.base_lin_vel * self.obs_scales.lin_vel, self.obs_buf, heightmap_data), dim=-1)
         return obs_buf, critic_obs_buf
     
     # --------------------------- reward functions---------------------------

--- a/legged_gym/envs/pointfoot_flat/pointfoot_flat_config.py
+++ b/legged_gym/envs/pointfoot_flat/pointfoot_flat_config.py
@@ -36,9 +36,9 @@ robot_type = os.getenv("ROBOT_TYPE")
 class BipedCfgPF(BaseConfig):
     class env:
         num_envs = 8192
-        num_observations = 30
-        num_critic_observations = 3 + num_observations
-        num_height_samples = 117
+        num_observations = 30  # Base observations (actual actor input: 30+3+3=36 with encoders, no heightmap)
+        num_critic_observations = 3 + num_observations + 81  # Base critic obs: base_lin_vel(3) + obs_buf(30) + raw_heightmap(81) = 114
+        num_height_samples = 81
         num_actions = 6
         env_spacing = 3.0  # not used with heightfields/trimeshes
         send_timeouts = True  # send time out information to the algorithm
@@ -48,7 +48,7 @@ class BipedCfgPF(BaseConfig):
         fail_to_terminal_time_s = 0.5
 
     class terrain:
-        mesh_type = "plane"  # "heightfield" # none, plane, heightfield or trimesh
+        mesh_type = "trimesh"  # "heightfield" # none, plane, heightfield or trimesh
         horizontal_scale = 0.1  # [m]
         vertical_scale = 0.005  # [m]
         border_size = 25  # [m]
@@ -57,11 +57,9 @@ class BipedCfgPF(BaseConfig):
         dynamic_friction = 0.4
         restitution = 0.8
         # rough terrain only:
-        measure_heights = False
+        measure_heights = True  # Enable heightmap measurement for heightmap encoder
         critic_measure_heights = True
         measured_points_x = [
-            -0.6,
-            -0.5,
             -0.4,
             -0.3,
             -0.2,
@@ -71,9 +69,7 @@ class BipedCfgPF(BaseConfig):
             0.2,
             0.3,
             0.4,
-            0.5,
-            0.6,
-        ]  # 1mx1.6m rectangle (without center line)
+        ]  # Reduced by removing front/back 2 points each (9 points total)
         measured_points_y = [-0.4, -0.3, -0.2, -0.1, 0.0, 0.1, 0.2, 0.3, 0.4]
         selected = False  # select a unique terrain type and pass all arguments
         terrain_kwargs = None  # Dict of arguments for selected terrain
@@ -340,6 +336,16 @@ class BipedCfgPPOPF(BaseConfig):
         activation = "elu"
         orthogonal_init = False
 
+    class Heightmap_Encoder:
+        output_detach = True  # Keep original design - independent encoder learning
+        num_input_dim = 81  # Use reduced measured_points (9x9=81) from base_task
+        num_output_dim = 0  # Disabled - use raw heightmap directly
+        hidden_dims = [256, 128]  # Network for GT heightmap compression
+        activation = "elu"
+        orthogonal_init = False
+        # Note: Encoder disabled - raw 81-dim heightmap will be used directly
+        # No noise parameters needed since we only use clean GT data
+
     class policy:
         init_noise_std = 1.0
         actor_hidden_dims = [512, 256, 128]
@@ -365,17 +371,19 @@ class BipedCfgPPOPF(BaseConfig):
         # Extra training params
         est_learning_rate = 1.0e-3
         ts_learning_rate = 1.0e-4
-        critic_take_latent = True
+        critic_take_latent = True  # Use latent features for critic
+        critic_use_gt_heightmap = True  # Use GT heightmap for critic privileged information
 
     class runner:
         encoder_class_name = "MLP_Encoder"
+        heightmap_encoder_class_name = "Heightmap_Encoder"
         policy_class_name = "ActorCritic"
         algorithm_class_name = "PPO"
         num_steps_per_env = 24  # per iteration
         max_iterations = 15000  # number of policy updates
 
         # logging
-        logger = "tensorboard"
+        logger = "wandb"
         exptid = ""
         wandb_project = "legged_gym_PF"
         save_interval = 500  # check for potential saves every this many iterations

--- a/legged_gym/envs/vec_env.py
+++ b/legged_gym/envs/vec_env.py
@@ -45,7 +45,7 @@ class VecEnv(ABC):
     extras: dict
     device: torch.device
     @abstractmethod
-    def step(self, actions: torch.Tensor) -> Tuple[torch.Tensor, Union[torch.Tensor, None], torch.Tensor, torch.Tensor, dict]:
+    def step(self, actions: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, dict, torch.Tensor, torch.Tensor, torch.Tensor]:
         pass
     @abstractmethod
     def reset(self, env_ids: Union[list, torch.Tensor]):

--- a/legged_gym/utils/math.py
+++ b/legged_gym/utils/math.py
@@ -51,6 +51,11 @@ def wrap_to_pi(angles):
 
 
 # @ torch.jit.script
+def torch_rand_float(lower, upper, shape, device):
+    # type: (float, float, Tuple[int, int], str) -> Tensor
+    return (upper - lower) * torch.rand(*shape, device=device) + lower
+
+# @ torch.jit.script
 def torch_rand_sqrt_float(lower, upper, shape, device):
     # type: (float, float, Tuple[int, int], str) -> Tensor
     r = 2 * torch.rand(*shape, device=device) - 1

--- a/legged_gym/utils/wandb_utils.py
+++ b/legged_gym/utils/wandb_utils.py
@@ -42,8 +42,8 @@ class WandbSummaryWriter(SummaryWriter):
             LEGGED_GYM_ROOT_DIR, "logs", cfg["experiment_name"]
         )
         wandb.init(
-            project=project,
-            entity=entity,
+            project="leggedgym_PF_Tron1A",
+            entity="kdyy1111-kwangwoon-university",
             name=cfg["exptid"],
             dir=wandb_dir,
         )


### PR DESCRIPTION
- Set heightmap_encoder num_output_dim to 0 to disable encoding
- Update critic observation dimension from 49 to 114 (3+30+81)
- Modify PPO act method to use raw heightmap from critic_obs
- Update pointfoot_flat to include actual heightmap data in critic_obs_buf
- Remove gt_heightmap parameter from act method calls
- Use measured_heights directly instead of encoded representation